### PR TITLE
Method for adding polygons precisely

### DIFF
--- a/Body.cpp
+++ b/Body.cpp
@@ -23,7 +23,29 @@ Body::Body( Shape *shape_, uint32 x, uint32 y )
   : shape( shape_->Clone( ) )
 {
   shape->body = this;
+  Initialize( );
+  shape->Initialize( );
   position.Set( (real)x, (real)y );
+}
+
+Body::Body( PolygonShape *poly_ )
+  : shape( poly_->Clone( ) )
+{
+  shape->body = this;
+  Initialize( );
+
+  //Set Body position such that original PolygonShape vertices are preserved
+  //Assume each vertex has been shifted equivalently during initialization
+  PolygonShape *polyShape = (PolygonShape*) shape;
+  Vec2 firstPoint = polyShape->m_vertices[0];
+  polyShape->Initialize( );
+  Vec2 shift = firstPoint - polyShape->m_vertices[0];
+  position.Set( (real)shift.x, (real)shift.y );
+  SetOrient( 0 );
+}
+
+void Body::Initialize( void )
+{
   velocity.Set( 0, 0 );
   angularVelocity = 0;
   torque = 0;
@@ -32,7 +54,6 @@ Body::Body( Shape *shape_, uint32 x, uint32 y )
   staticFriction = 0.5f;
   dynamicFriction = 0.3f;
   restitution = 0.2f;
-  shape->Initialize( );
   r = Random( 0.2f, 1.0f );
   g = Random( 0.2f, 1.0f );
   b = Random( 0.2f, 1.0f );

--- a/Body.h
+++ b/Body.h
@@ -21,11 +21,16 @@
 #define BODY_H
 
 struct Shape;
+struct PolygonShape;
 
 // http://gamedev.tutsplus.com/tutorials/implementation/how-to-create-a-custom-2d-physics-engine-the-core-engine/
 struct Body
 {
   Body( Shape *shape_, uint32 x, uint32 y );
+
+  Body( PolygonShape *poly_ );
+
+  void Initialize( void );
 
   void ApplyForce( const Vec2& f )
   {

--- a/Scene.cpp
+++ b/Scene.cpp
@@ -150,3 +150,11 @@ Body *Scene::Add( Shape *shape, uint32 x, uint32 y )
   bodies.push_back( b );
   return b;
 }
+
+Body *Scene::Add( PolygonShape *poly )
+{
+  assert( poly );
+  Body *b = new Body( poly );
+  bodies.push_back( b );
+  return b;
+}

--- a/Scene.h
+++ b/Scene.h
@@ -34,6 +34,7 @@ struct Scene
   void Step( void );
   void Render( void );
   Body *Add( Shape *shape, uint32 x, uint32 y );
+  Body *Add( PolygonShape *poly );
   void Clear( void );
 
   f32 m_dt;


### PR DESCRIPTION
Hi,

I have been experimenting with your engine in a project I am beginning. After trying to create an environment consisting of static polygons, I came to understand that a polygon's vertices are shifted such that its centroid is (0,0) upon initialization. It does not seem possible to add a PolygonShape to a Scene with the vertices of the PolygonShape preserved in the resulting Body unless its centroid is calculated or the vertices shift is recorded by the user.

To circumvent this, I have added a method to Scene which allows adding of a PolygonShape without a position.  The Body position is set such that the Body would be rendered with the vertices of the original PolygonShape. This compensation is implemented in Body.cpp and is unobtrusive rather than elegant.

Chase